### PR TITLE
Fix a documentation warning in header file

### DIFF
--- a/ServiceLocator/NLServiceLocator.h
+++ b/ServiceLocator/NLServiceLocator.h
@@ -49,7 +49,7 @@
  
  @param service Service that will be registered in service locator.
 
- @param service Protocol that service conforms and will be used for registration.
+ @param protocol Protocol that service conforms and will be used for registration.
 
 */
 + (void)registerService:(id)service forProtocol:(Protocol *)protocol;


### PR DESCRIPTION
The parameter name in the docset was incorrect. It creates a warning in XCode.